### PR TITLE
Changed Insight base urls for network

### DIFF
--- a/src/Insight.ts
+++ b/src/Insight.ts
@@ -4,8 +4,8 @@ import { INetworkInfo } from "./Network"
 import { NetworkNames } from "./constants"
 
 const INSIGHT_BASEURLS: { [key: string]: string } = {
-  [NetworkNames.MAINNET]: "https://explorer.qtum.org/insight-api",
-  [NetworkNames.TESTNET]: "https://testnet.qtum.org/insight-api",
+  [NetworkNames.MAINNET]: "https://api.qiswap.com/insight-api",
+  [NetworkNames.TESTNET]: "https://testnet-api.qiswap.com/insight-api",
   [NetworkNames.REGTEST]: "http://localhost:3001/insight-api",
 }
 


### PR DESCRIPTION
Changed Insight base urls for network mainnet and testnet to use api.qiswap.com.
Ran the tests, all passed.
Also tried out the changes in this PR in browserify-example & the qrypto repo using [yalc](https://github.com/wclr/yalc) - everything seems to be working fine.